### PR TITLE
Fix panic in runoff, add integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --all-features
+          args: --all-features --all-targets
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:

--- a/crates/core/benches/world_gen.rs
+++ b/crates/core/benches/world_gen.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use terra::{Meter3, NoiseFnConfig, World, WorldConfig};
+use terra::{World, WorldConfig};
 
 fn criterion_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("world-generation");

--- a/crates/core/src/world/generate/runoff/mod.rs
+++ b/crates/core/src/world/generate/runoff/mod.rs
@@ -19,6 +19,7 @@ use crate::{
     },
 };
 use fnv::FnvBuildHasher;
+use log::trace;
 use std::{
     cmp::Ordering,
     collections::{HashMap, VecDeque},
@@ -151,6 +152,10 @@ impl<'a> Continent<'a> {
     /// system, meaning its runoff doesn't affect any other continents in any
     /// way.
     fn sim_continent_runoff(&mut self) {
+        trace!(
+            "Simulating runoff for continent [first_tile={}]",
+            self.tiles.first().unwrap().0
+        );
         self.initialize_runoff();
         self.push_downhill();
         self.sim_backflow();
@@ -249,8 +254,11 @@ impl<'a> Continent<'a> {
                     } else {
                         // The other basin has never donated to us, which means
                         // we can safely overflow into them
-                        let other_basin =
-                            basins.get_mut(other_basin_key).unwrap();
+                        let other_basin = basins
+                            .get_mut(other_basin_key)
+                            .unwrap_or_else(|| {
+                                panic!("unknown basin key: {}", other_basin_key)
+                            });
                         other_basin.overflow(basin_key, overflow_vol);
 
                         // Re-queue the receiving basin (if it isn't already)

--- a/crates/core/tests/world_gen.rs
+++ b/crates/core/tests/world_gen.rs
@@ -1,0 +1,20 @@
+use terra::{World, WorldConfig};
+
+#[test]
+fn test_world_gen_default() {
+    let world = World::generate(WorldConfig::default());
+    assert_eq!(world.tiles().len(), 30301);
+}
+
+#[test]
+fn test_world_gen_large() {
+    // This config had issues in the past with runoff
+    let config = WorldConfig {
+        seed: 1021522790211909,
+        radius: 400,
+        edge_buffer_size: 100,
+        ..Default::default()
+    };
+    let world = World::generate(config);
+    assert_eq!(world.tiles().len(), 481201);
+}


### PR DESCRIPTION
- Fixed a panic in runoff that only occurred in certain scenarios
- Added a couple simple integration tests
- Added `--all-targets` to `cargo check` in CI