### PR TITLE
Add runoff traversal tracking

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -14,6 +14,7 @@
 //!
 //! See [WorldConfig] for details on how the world generation can be customized.
 
+#![feature(cmp_min_max_by)]
 #![feature(const_fn)]
 
 mod config;

--- a/crates/core/src/util.rs
+++ b/crates/core/src/util.rs
@@ -18,6 +18,22 @@ use std::{
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 
+/// A macro to unwrap an option to its `Some` value, and bail out of the current
+/// function with an [anyhow::Error] if not. Can only be used in functions that
+/// return an [anyhow::Result].
+#[macro_export]
+macro_rules! unwrap_or_bail {
+    // ($msg:literal $(,)?) => { ... };
+    // ($err:expr $(,)?) => { ... };
+    ($opt:expr, $fmt:expr, $($arg:tt)*) => {
+        match $opt {
+            Some(v) => v,
+            // None => bail!($fmt, $($arg)*)
+            None => return Err(anyhow::anyhow!($fmt, $($arg)*)),
+        }
+    };
+}
+
 /// A macro to measure the evaluation time of an expression. Wraps an
 /// expression, and outputs a tuple of the value of the expression with the
 /// elapsed time, as a [Duration](std::time::Duration).
@@ -63,6 +79,7 @@ macro_rules! timed {
     Copy,
     Clone,
     Debug,
+    Default,
     Display,
     PartialEq,
     PartialOrd,
@@ -92,6 +109,7 @@ pub struct Meter(pub f64);
     Copy,
     Clone,
     Debug,
+    Default,
     Display,
     PartialEq,
     PartialOrd,
@@ -121,6 +139,7 @@ pub struct Meter2(pub f64);
     Copy,
     Clone,
     Debug,
+    Default,
     Display,
     PartialEq,
     PartialOrd,

--- a/crates/core/src/world/generate/elevation.rs
+++ b/crates/core/src/world/generate/elevation.rs
@@ -6,7 +6,7 @@ use crate::{
         World,
     },
 };
-use anyhow::bail;
+use anyhow::ensure;
 use noise::Fbm;
 
 /// Generate an elevation map using a noise function.
@@ -19,14 +19,15 @@ impl Generate for ElevationGenerator {
         let normal_range = NumRange::normal_range();
         let noise_fn: TileNoiseFn<Fbm, Meter> =
             TileNoiseFn::new(&mut world.rng, &config.elevation, normal_range);
-        if config.edge_buffer_size >= config.radius {
-            bail!(
-                "config.edge_buffer_size ({}) \
+
+        ensure!(
+            config.edge_buffer_size < config.radius,
+            "config.edge_buffer_size ({}) \
                 must be less than config.radius ({})",
-                config.edge_buffer_size,
-                config.radius
-            );
-        }
+            config.edge_buffer_size,
+            config.radius
+        );
+
         let buffer_range = NumRange::new(
             (config.radius - config.edge_buffer_size + 1) as f64,
             config.radius as f64,

--- a/crates/core/src/world/generate/ocean.rs
+++ b/crates/core/src/world/generate/ocean.rs
@@ -43,6 +43,7 @@ impl Generate for OceanGenerator {
                     // participate in runoff simulation later (because it's
                     // water)
                     tile.set_runoff(Meter3(0.0))?;
+                    tile.set_runoff_egress(Default::default());
                 }
             }
         }

--- a/crates/core/src/world/hex.rs
+++ b/crates/core/src/world/hex.rs
@@ -53,16 +53,16 @@ impl HexPoint {
         -(self.x + self.y)
     }
 
+    /// Calculate the path distance between two points, meaning the number of
+    /// hops it takes to get from one to the other. 0 if the points are equal,
+    /// 1 if they are adjacent, 2 if there is 1 point between them, etc.
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
     pub fn distance_to(&self, other: HexPoint) -> usize {
-        *[
-            (self.x() - other.x()).abs(),
-            (self.y() - other.y()).abs(),
-            (self.z() - other.z()).abs(),
-        ]
-        .iter()
-        .max()
-        .unwrap() as usize // safe since we know the iter is never empty
+        // https://www.redblobgames.com/grids/hexagons/#distances
+        ((self.x() - other.x()).abs()
+            + (self.y() - other.y()).abs()
+            + (self.z() - other.z()).abs()) as usize
+            / 2
     }
 }
 
@@ -320,7 +320,7 @@ pub trait HasHexPosition: Sized {
 ///
 /// See this page for more info (we use "flat topped" tiles):
 /// https://www.redblobgames.com/grids/hexagons/#coordinates-cube
-#[derive(Copy, Clone, Debug, EnumIter, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, EnumIter, PartialEq, Eq, Hash, Serialize)]
 pub enum HexDirection {
     Up,
     UpRight,

--- a/typescript/webpack.config.js
+++ b/typescript/webpack.config.js
@@ -37,6 +37,10 @@ module.exports = {
     new WasmPackPlugin({
       outName: "terra-wasm",
       crateDirectory: wasmDir,
+      watchDirectories: [
+        path.resolve(__dirname, "../crates/core"),
+        path.resolve(wasmDir, "src"), // make sure not to include the pkg dir
+      ],
       outDir: path.resolve(wasmDir, "pkg"),
     }),
   ],


### PR DESCRIPTION
- Added `runoff_egress` field to `Tile` and `TileBuilder`, which tracks how much runoff has left a tile in each direction
- Added display for runoff egress to the `Runoff` tile lens, which looks pretty lit (see screenshot)
- Added a macro `unwrap_or_bail`, which is neat

Blue is collected runoff, green is total runoff egress. i.e. lakes & rivers (kinda)
![image](https://user-images.githubusercontent.com/2382935/104399274-5518ca80-551e-11eb-875f-4ae2ba2cb091.png)
