### PR TITLE
Add STL export format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,6 +297,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "float-cmp"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +865,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "stl_io"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c68e41108b3ec269d885cc56af66cd15f1392f68d2ae461df86d7d3285f065d"
+dependencies = [
+ "byteorder",
+ "float-cmp",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,6 +975,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simple_logger",
+ "stl_io",
  "structopt",
  "strum",
  "svg",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,6 +15,7 @@ rmp-serde = "0.15"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 simple_logger = "1.11"
+stl_io = "0.6"
 structopt = "0.3"
 strum = "*"
 svg = "0.8"

--- a/crates/cli/configs/print.toml
+++ b/crates/cli/configs/print.toml
@@ -1,0 +1,4 @@
+# A world to be 3D-printed
+edge_buffer_fraction = 0.0
+radius = 30
+seed = 6419875009622483798

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,3 +1,4 @@
+mod stl;
 mod svg;
 
 use anyhow::{bail, Context};
@@ -41,6 +42,8 @@ struct Opt {
     /// cfg - The full config object used for the world, in TOML format
     ///
     /// svg - 2D rendering of the world
+    ///
+    /// stl - 3D rendering of the world
     #[structopt(short = "f", long)]
     output_formats: Vec<OutputFormat>,
 
@@ -74,6 +77,8 @@ enum OutputFormat {
     Cfg,
     /// Render the world as a 2D SVG
     Svg,
+    /// Render the world as a 3D STL
+    Stl,
     /* If you change this, make sure to update the help text for
      * `--output-formats`! */
 }
@@ -84,6 +89,7 @@ impl OutputFormat {
             Self::Bin => "bin",
             Self::Cfg => "toml",
             Self::Svg => "svg",
+            Self::Stl => "stl",
         }
     }
 }
@@ -135,6 +141,14 @@ fn gen_output(
                 // Render the world in 2D
                 let doc = svg::draw_world(world, render_options);
                 Ok(doc.to_string().into_bytes())
+            }
+            OutputFormat::Stl => {
+                // Render the world in 3D
+                let mesh = stl::draw_world(world, render_options);
+                let mut buffer = Vec::<u8>::new();
+                stl_io::write_stl(&mut buffer, mesh.iter())
+                    .context("error serializing STL")?;
+                Ok(buffer)
             }
         }
     }

--- a/crates/cli/src/stl.rs
+++ b/crates/cli/src/stl.rs
@@ -1,0 +1,159 @@
+use crate::RenderOptions;
+use stl_io::{Normal, Triangle, Vertex};
+use strum::IntoEnumIterator;
+use terra::{
+    HasHexPosition, HexAxialDirection, HexDirection, HexDirectionMap, Point2,
+    Tile, World,
+};
+
+pub fn draw_world(world: &World, _options: RenderOptions) -> Vec<Triangle> {
+    let mut mesh =
+        Vec::with_capacity(world.tiles().len() * TileSolid::TRIANGLES_PER_TILE);
+
+    for tile in world.tiles().values() {
+        let solid = TileSolid::new(world, tile);
+        solid.add_to_mesh(&mut mesh);
+    }
+
+    mesh
+}
+
+/// A convenience struct for converting a tile into STL triangles.
+#[derive(Clone, Debug)]
+struct TileSolid {
+    perimeter_points_2d: Vec<Point2>,
+    bottom_perimeter_vertices: Vec<Vertex>,
+    top_z: f32,
+    top_perimeter_vertices: Vec<Vertex>,
+    adjacents_z: HexDirectionMap<f32>,
+}
+
+impl TileSolid {
+    /// AT MOST 20 triangles per tile:
+    /// - 4 for the top
+    /// - MAXIMUM of 2 per side, times 6 sides
+    ///   - These get culled if adjacent to a taller tile
+    /// - 4 for the bottom
+    const TRIANGLES_PER_TILE: usize = 20;
+
+    /// Vertex indices for the vertices of tile's face (top or bottom). Together
+    /// these form the triangles that make up the face. Starts at the top-left
+    /// and goes clockwise, the same as [HexAxialDirection::CLOCKWISE].
+    const FACE_INDICES: &'static [[usize; 3]] =
+        &[[0, 3, 1], [0, 4, 3], [1, 3, 2], [0, 5, 4]];
+
+    fn new(world: &World, tile: &Tile) -> Self {
+        let center_2d = tile.position().to_point2();
+        let perimeter_points_2d: Vec<_> = HexAxialDirection::CLOCKWISE
+            .iter()
+            .cloned()
+            .map(|dir| center_2d + dir.to_vector2())
+            .collect();
+
+        let bottom_perimeter_vertices: Vec<_> = perimeter_points_2d
+            .iter()
+            .map(|p| Vertex::new([p.x as f32, p.y as f32, 0.0]))
+            .collect();
+
+        let top_z = tile.height().0 as f32;
+        let top_perimeter_vertices: Vec<_> = perimeter_points_2d
+            .iter()
+            .map(|p| Vertex::new([p.x as f32, p.y as f32, top_z]))
+            .collect();
+
+        let pos = tile.position();
+        let tiles = world.tiles();
+        let adjacents_z = HexDirection::iter()
+            .filter_map(|dir| {
+                let adj_pos = pos + dir.to_vector();
+                let adj_tile = tiles.get(&adj_pos)?;
+                Some((dir, adj_tile.height().0 as f32))
+            })
+            .collect();
+
+        Self {
+            perimeter_points_2d,
+            bottom_perimeter_vertices,
+            top_z,
+            top_perimeter_vertices,
+            adjacents_z,
+        }
+    }
+
+    /// Convert this tile to triangle soup and add them to the soup pot.
+    fn add_to_mesh(self, mesh: &mut Vec<Triangle>) {
+        // Normals are bullshit anyway, most programs don't respect them
+        let normal = Normal::new([0.0, 0.0, 0.0]);
+
+        // REMEMBER: We use the right-hand rule, so all vertices are
+        // COUNTER-CLOCKWISE when looking at the visible side.
+
+        // Bottom face
+        for [i1, i2, i3] in Self::FACE_INDICES {
+            let vertices = [
+                self.bottom_perimeter_vertices[*i1],
+                self.bottom_perimeter_vertices[*i2],
+                self.bottom_perimeter_vertices[*i3],
+            ];
+            mesh.push(Triangle { normal, vertices })
+        }
+
+        for [i1, i2, i3] in Self::FACE_INDICES {
+            let vertices = [
+                // Reverse these so the hex faces up, not down
+                self.top_perimeter_vertices[*i3],
+                self.top_perimeter_vertices[*i2],
+                self.top_perimeter_vertices[*i1],
+            ];
+            mesh.push(Triangle { normal, vertices })
+        }
+
+        // For each side of the hexagon, draw 2 triangles
+        for (i, dir) in HexDirection::iter().enumerate() {
+            let bottom_z = *self.adjacents_z.get(&dir).unwrap_or(&0.0);
+
+            // If the adjacent tile in this direction is taller, then no need
+            // to draw a side here because it won't be visible.
+            if bottom_z <= self.top_z {
+                // Some setup variables
+                let i1 = i;
+                let i2 = (i + 1) % 6;
+                let p1 = self.perimeter_points_2d[i1];
+                let p2 = self.perimeter_points_2d[i2];
+
+                let bottom_v1 =
+                    Vertex::new([p1.x as f32, p1.y as f32, bottom_z]);
+                let bottom_v2 =
+                    Vertex::new([p2.x as f32, p2.y as f32, bottom_z]);
+
+                let top_v1 = self.top_perimeter_vertices[i1];
+                let top_v2 = self.top_perimeter_vertices[i2];
+
+                // Side face - here's what each one looks like from the OUTSIDE
+                // We slice it into two triangles for our triangle soup
+                //
+                //    top_v1       top_v2
+                //          +-----+
+                //          |\    |
+                //          | \   |
+                //          |  \  |
+                //          |   \ |
+                //          |    \|
+                //          +-----+
+                // bottom_v1       bottom_v2
+
+                // Remember, all vertices are CCW (right-hand rule)
+                // Top-right triangle
+                mesh.push(Triangle {
+                    normal,
+                    vertices: [bottom_v2, top_v2, top_v1],
+                });
+                // Bottom-left triangle
+                mesh.push(Triangle {
+                    normal,
+                    vertices: [top_v1, bottom_v1, bottom_v2],
+                });
+            }
+        }
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -25,10 +25,11 @@ mod world;
 
 pub use crate::{
     config::{GeoFeatureConfig, NoiseFnConfig, RainfallConfig, WorldConfig},
-    util::{Color3, Meter, Meter2, Meter3, NumRange, RangeValue},
+    util::{Color3, Meter, Meter2, Meter3, NumRange, Point2, RangeValue},
     world::{
         hex::{
-            HasHexPosition, HexAxialDirection, HexAxis, HexDirection, HexPoint,
+            HasHexPosition, HexAxialDirection, HexAxis, HexDirection,
+            HexDirectionMap, HexPoint, HexPointMap,
         },
         Biome, BiomeType, GeoFeature, Tile, TileLens, World,
     },

--- a/crates/core/src/world/hex.rs
+++ b/crates/core/src/world/hex.rs
@@ -199,6 +199,29 @@ impl HexDirection {
         }
     }
 
+    /// Get a pair of [HexAxialDirection]s that denote the endpoints of a side
+    /// of a tile. The direction defines which side we're talking about, then
+    /// the directions define the vertices relative to the center of the tile.
+    /// These will always been returned in clockwise order.
+    pub fn endpoints(self) -> (HexAxialDirection, HexAxialDirection) {
+        match self {
+            Self::Up => (HexAxialDirection::Y_POS, HexAxialDirection::Z_NEG),
+            Self::UpRight => {
+                (HexAxialDirection::Z_NEG, HexAxialDirection::X_POS)
+            }
+            Self::DownRight => {
+                (HexAxialDirection::X_POS, HexAxialDirection::Y_NEG)
+            }
+            Self::Down => (HexAxialDirection::Y_NEG, HexAxialDirection::Z_POS),
+            Self::DownLeft => {
+                (HexAxialDirection::Z_POS, HexAxialDirection::X_NEG)
+            }
+            Self::UpLeft => {
+                (HexAxialDirection::X_NEG, HexAxialDirection::Y_POS)
+            }
+        }
+    }
+
     /// Get an vector offset that would move a point one tile in this direction
     pub fn to_vector(self) -> HexVector {
         match self {
@@ -252,7 +275,7 @@ impl HexDirection {
 ///
 /// See this page for more info (we use "flat topped" tiles):
 /// https://www.redblobgames.com/grids/hexagons/#coordinates-cube
-#[derive(Copy, Clone, Debug, EnumIter)]
+#[derive(Copy, Clone, Debug, EnumIter, PartialEq, Eq, Hash)]
 pub enum HexAxis {
     X,
     Y,
@@ -267,40 +290,57 @@ pub enum HexAxis {
 ///
 /// See this page for more info (we use "flat topped" tiles):
 /// https://www.redblobgames.com/grids/hexagons/#coordinates-cube
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct HexAxialDirection {
     pub axis: HexAxis,
     pub positive: bool,
 }
 
 impl HexAxialDirection {
+    pub const X_NEG: Self = Self {
+        axis: HexAxis::X,
+        positive: false,
+    };
+    pub const X_POS: Self = Self {
+        axis: HexAxis::X,
+        positive: true,
+    };
+    pub const Y_NEG: Self = Self {
+        axis: HexAxis::Y,
+        positive: false,
+    };
+    pub const Y_POS: Self = Self {
+        axis: HexAxis::Y,
+        positive: true,
+    };
+    pub const Z_NEG: Self = Self {
+        axis: HexAxis::Z,
+        positive: false,
+    };
+    pub const Z_POS: Self = Self {
+        axis: HexAxis::Z,
+        positive: true,
+    };
+
     /// A list of all hex axial directions. Starts with the negative x (which
     /// is due left of the origin), then goes around clockwise from there.
     pub const ALL: &'static [Self] = &[
-        Self {
-            axis: HexAxis::X,
-            positive: false,
-        },
-        Self {
-            axis: HexAxis::Y,
-            positive: true,
-        },
-        Self {
-            axis: HexAxis::Z,
-            positive: false,
-        },
-        Self {
-            axis: HexAxis::X,
-            positive: true,
-        },
-        Self {
-            axis: HexAxis::Y,
-            positive: false,
-        },
-        Self {
-            axis: HexAxis::Z,
-            positive: true,
-        },
+        Self::X_NEG,
+        Self::X_POS,
+        Self::Y_NEG,
+        Self::Y_POS,
+        Self::Z_NEG,
+        Self::Z_POS,
+    ];
+    /// List of all hex axial directions, in clockwise order starting from the
+    /// top-left vertex of a tile.
+    pub const CLOCKWISE: &'static [Self] = &[
+        Self::Y_POS,
+        Self::Z_NEG,
+        Self::X_POS,
+        Self::Y_NEG,
+        Self::Z_POS,
+        Self::X_NEG,
     ];
 
     pub fn signum(self) -> i16 {


### PR DESCRIPTION
Added the `stl` output format to the CLI. Allows us to export worlds as a 3D model (yay for additive manufacturing)