### PR TITLE
[#28] Replace Results with panics for internal errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ crates/cli/world/
 
 *.d.ts
 !declarations.d.ts
+.DS_Store

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -10,6 +10,7 @@
 //! let world = World::generate(config).unwrap();
 //! println!("{}", world.tiles().len());
 //! // From here you can display/use the world however you like.
+//! // See other methods on the World struct for possible output formats.
 //! ```
 //!
 //! See [WorldConfig] for details on how the world generation can be customized.

--- a/crates/core/src/util/mod.rs
+++ b/crates/core/src/util/mod.rs
@@ -21,18 +21,16 @@ use std::{
     ops,
 };
 
-/// A macro to unwrap an option to its `Some` value, and bail out of the current
-/// function with an [anyhow::Error] if not. Can only be used in functions that
-/// return an [anyhow::Result].
+/// A macro to unwrap an option to its `Some` value, and panic if `None`. This
+/// is the same as [Option::unwrap], except that it accepts a format string
+/// and format arguments, allowing for more flexibility in error messages.
 #[macro_export]
-macro_rules! unwrap_or_bail {
-    // ($msg:literal $(,)?) => { ... };
-    // ($err:expr $(,)?) => { ... };
+macro_rules! unwrap {
     ($opt:expr, $fmt:expr, $($arg:tt)*) => {
         match $opt {
             Some(v) => v,
             // None => bail!($fmt, $($arg)*)
-            None => return Err(anyhow::anyhow!($fmt, $($arg)*)),
+            None => panic!($fmt, $($arg)*),
         }
     };
 }

--- a/crates/core/src/util/svg.rs
+++ b/crates/core/src/util/svg.rs
@@ -24,7 +24,7 @@ pub fn world_to_svg(
     world: &World,
     lens: TileLens,
     show_features: bool,
-) -> anyhow::Result<Document> {
+) -> Document {
     // Grow the view box based on the world size. The world height will always
     // be the larger size, so scale it based on that. The +1 provides a bit of
     // buffer space
@@ -44,19 +44,15 @@ pub fn world_to_svg(
         .add(Comment::new(format!("\n{:#?}\n", world.config())));
 
     for tile in world.tiles().values() {
-        let polygon = draw_tile(tile, lens, show_features)?;
+        let polygon = draw_tile(tile, lens, show_features);
         document = document.add(polygon);
     }
 
-    Ok(document)
+    document
 }
 
 /// Generate an SVG polygon for a single tile
-fn draw_tile(
-    tile: &Tile,
-    lens: TileLens,
-    show_features: bool,
-) -> anyhow::Result<Group> {
+fn draw_tile(tile: &Tile, lens: TileLens, show_features: bool) -> Group {
     let pos = tile.position();
     let pos2d = pos.to_point2();
 
@@ -76,7 +72,7 @@ fn draw_tile(
                         })
                         .collect::<Vec<_>>(),
                 )
-                .set("fill", lens.tile_color(tile)?.to_html()),
+                .set("fill", lens.tile_color(tile).to_html()),
         );
 
     // Add overlays for each geo feature
@@ -101,5 +97,5 @@ fn draw_tile(
         }
     }
 
-    Ok(group)
+    group
 }

--- a/crates/core/src/world/generate/biome.rs
+++ b/crates/core/src/world/generate/biome.rs
@@ -43,7 +43,7 @@ const POINTS: &[BiomePoint] = &[
 pub struct BiomeGenerator;
 
 impl Generate for BiomeGenerator {
-    fn generate(&self, world: &mut WorldBuilder) -> anyhow::Result<()> {
+    fn generate(&self, world: &mut WorldBuilder) {
         // We're going to normalize all the elevations so we can use a
         // consistent set of coefficients below. We don't want to map from the
         // full range though, because 99% of the tiles below sea level we won't
@@ -62,8 +62,8 @@ impl Generate for BiomeGenerator {
         {
             // Normalize these values so we don't have to update this code when
             // we change the elevation/humidity range bounds
-            let elevation_norm = elev_input_range.normalize(tile.elevation()?);
-            let humidity = tile.humidity()?;
+            let elevation_norm = elev_input_range.normalize(tile.elevation());
+            let humidity = tile.humidity();
 
             // Do a naive search to find the nearest point. This is O(n) which
             // isn't particularly efficient, but since the number of points is
@@ -75,7 +75,5 @@ impl Generate for BiomeGenerator {
                 .unwrap(); // safe because we know POINTS is never empty
             tile.set_biome(biome);
         }
-
-        Ok(())
     }
 }

--- a/crates/core/src/world/generate/elevation.rs
+++ b/crates/core/src/world/generate/elevation.rs
@@ -12,7 +12,7 @@ use crate::{
 pub struct ElevationGenerator;
 
 impl Generate for ElevationGenerator {
-    fn generate(&self, world: &mut WorldBuilder) -> anyhow::Result<()> {
+    fn generate(&self, world: &mut WorldBuilder) {
         let config = world.config;
         let normal_range = NumRange::normal_range();
         let noise_fn: TileNoiseFn<Meter> =
@@ -63,9 +63,7 @@ impl Generate for ElevationGenerator {
                 .convert::<Meter>()
                 .map_to(elev_range)
                 .inner();
-            tile.set_elevation(elev)?;
+            tile.set_elevation(elev);
         }
-
-        Ok(())
     }
 }

--- a/crates/core/src/world/generate/ocean.rs
+++ b/crates/core/src/world/generate/ocean.rs
@@ -18,11 +18,11 @@ const MIN_COAST_ELEV: Meter = Meter(-3.0);
 pub struct OceanGenerator;
 
 impl Generate for OceanGenerator {
-    fn generate(&self, world: &mut WorldBuilder) -> anyhow::Result<()> {
+    fn generate(&self, world: &mut WorldBuilder) {
         // Find all clusters of tiles that are entirely below sea level
         let clusters = Cluster::predicate(&mut world.tiles, |tile| {
-            Ok(tile.elevation()? <= World::SEA_LEVEL)
-        })?;
+            tile.elevation() <= World::SEA_LEVEL
+        });
 
         for cluster in clusters {
             // The odds of this cluster becoming an ocean are proportional to
@@ -33,7 +33,7 @@ impl Generate for OceanGenerator {
             if cluster.tiles().len() as f32 >= threshold {
                 // Update every tile in this cluster to be coast/ocean
                 for (_, tile) in cluster.into_tiles() {
-                    let biome = if tile.elevation()? >= MIN_COAST_ELEV {
+                    let biome = if tile.elevation() >= MIN_COAST_ELEV {
                         Biome::Coast
                     } else {
                         Biome::Ocean
@@ -42,11 +42,9 @@ impl Generate for OceanGenerator {
                     // Initialize runoff tiles now, since this tile won't
                     // participate in runoff simulation later (because it's
                     // water)
-                    tile.set_runoff(Meter3(0.0))?;
+                    tile.set_runoff(Meter3(0.0));
                 }
             }
         }
-
-        Ok(())
     }
 }

--- a/crates/core/src/world/generate/water_feature.rs
+++ b/crates/core/src/world/generate/water_feature.rs
@@ -13,12 +13,12 @@ use crate::{
 pub struct WaterFeatureGenerator;
 
 impl Generate for WaterFeatureGenerator {
-    fn generate(&self, world: &mut WorldBuilder) -> anyhow::Result<()> {
+    fn generate(&self, world: &mut WorldBuilder) {
         let cfg = world.config.geo_feature;
         for tile in world.tiles.values_mut() {
             // Lake
-            if tile.runoff()? >= cfg.lake_runoff_threshold {
-                tile.add_feature(GeoFeature::Lake)?;
+            if tile.runoff() >= cfg.lake_runoff_threshold {
+                tile.add_feature(GeoFeature::Lake);
             }
 
             // River exit
@@ -33,15 +33,14 @@ impl Generate for WaterFeatureGenerator {
                     tile.add_feature(GeoFeature::RiverEntrance {
                         direction: dir,
                         volume: runoff_net,
-                    })?;
+                    });
                 } else if runoff_net < -cfg.river_runoff_traversed_threshold {
                     tile.add_feature(GeoFeature::RiverExit {
                         direction: dir,
                         volume: -runoff_net,
-                    })?;
+                    });
                 }
             }
         }
-        Ok(())
     }
 }

--- a/crates/core/src/world/generate/wind.rs
+++ b/crates/core/src/world/generate/wind.rs
@@ -11,11 +11,10 @@ use strum::IntoEnumIterator;
 pub struct WindGenerator;
 
 impl Generate for WindGenerator {
-    fn generate(&self, world: &mut WorldBuilder) -> anyhow::Result<()> {
+    fn generate(&self, world: &mut WorldBuilder) {
         // unwrap is safe because HexAxis::iter() can't be empty
         let axis = HexAxis::iter().choose_stable(&mut world.rng).unwrap();
         let positive: bool = world.rng.gen_bool(0.5);
         world.wind_direction = Some(HexAxialDirection { axis, positive });
-        Ok(())
     }
 }

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -82,12 +82,8 @@ impl Terra {
     /// doesn't support impls on enums so we have to do this
     /// https://github.com/rustwasm/wasm-bindgen/issues/1715
     #[wasm_bindgen]
-    pub fn tile_color(
-        &self,
-        tile: &Tile,
-        lens: TileLens,
-    ) -> Result<Color3, JsValue> {
-        lens.tile_color(tile).map_err(to_js_error)
+    pub fn tile_color(&self, tile: &Tile, lens: TileLens) -> Color3 {
+        lens.tile_color(tile)
     }
 }
 
@@ -110,32 +106,29 @@ impl WasmWorld {
             .unchecked_into()
     }
 
+    /// See [terra::World::tile_render_height]
     pub fn tile_render_height(&self, tile: &Tile) -> f64 {
         self.0.tile_render_height(tile)
     }
 
     /// See [terra::World::to_json]
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        self.0.to_json().map_err(to_js_error)
+    pub fn to_json(&self) -> String {
+        self.0.to_json()
     }
 
     /// See [terra::World::to_bin]
-    pub fn to_bin(&self) -> Result<Vec<u8>, JsValue> {
-        self.0.to_bin().map_err(to_js_error)
+    pub fn to_bin(&self) -> Vec<u8> {
+        self.0.to_bin()
     }
 
     /// See [terra::World::to_svg]
-    pub fn to_svg(
-        &self,
-        lens: TileLens,
-        show_features: bool,
-    ) -> Result<String, JsValue> {
-        self.0.to_svg(lens, show_features).map_err(to_js_error)
+    pub fn to_svg(&self, lens: TileLens, show_features: bool) -> String {
+        self.0.to_svg(lens, show_features)
     }
 
     /// See [terra::World::to_stl]
-    pub fn to_stl(&self) -> Result<Vec<u8>, JsValue> {
-        self.0.to_stl().map_err(to_js_error)
+    pub fn to_stl(&self) -> Vec<u8> {
+        self.0.to_stl()
     }
 }
 


### PR DESCRIPTION
Closes #28 

According to the rust book (https://doc.rust-lang.org/book/ch09-03-to-panic-or-not-to-panic.html), you should panic when internal assumptions about values or logic are broken in ways that the user cannot recover from. This describes 90% of the cases in which we were using results (for internal logic bugs). This commit replaces those all with panics. This cleans up a lot of stuff by removing results from a ton of functions. This should make it easier to trace down logic errors and also just generally keep return types cleaner.