### PR TITLE
[#35] Fix duplicated runoff bug

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -14,6 +14,7 @@ svg = ["dep:svg"]
 
 [dependencies]
 anyhow = "1.0"
+assert_approx_eq = "1.1"
 derive_more = "0.99"
 fnv = "1.0"
 indexmap = "1.6"
@@ -28,9 +29,6 @@ stl_io = {version = "0.6", optional = true}
 strum = {version = "0.20", features = ["derive"]}
 svg = {version = "0.8", optional = true}
 validator = {version = "0.12", default-features = false, features = ["derive"]}
-
-[dev-dependencies]
-assert_approx_eq = "1.1"
 
 # wasm-only dependencies
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/core/src/render/mod.rs
+++ b/crates/core/src/render/mod.rs
@@ -108,11 +108,12 @@ impl WorldRenderer {
                 if tile.biome().biome_type() == BiomeType::Water {
                     Color3::new(0.5, 0.5, 0.5)
                 } else {
+                    // Neither value we use here has a hard cap, so we use
+                    // arbitrary max values based on what's common/reasonable,
+                    // and anything over that will just be clamped down
                     let normal_runoff = NumRange::new(Meter3(0.0), Meter3(5.0))
                         .value(tile.runoff())
                         .normalize()
-                        // Runoff doesn't have a fixed range so we have to clamp
-                        // this to make sure we don't overflow the color value
                         .clamp()
                         .convert::<f64>()
                         .inner() as f32;
@@ -120,8 +121,6 @@ impl WorldRenderer {
                         NumRange::new(Meter3(0.0), Meter3(1000.0))
                             .value(tile.runoff_egress())
                             .normalize()
-                            // Runoff egress ALSO doesn't have a fixed range so
-                            // we have to clamp it as well
                             .clamp()
                             .convert::<f64>()
                             .inner() as f32;

--- a/crates/core/src/util/mod.rs
+++ b/crates/core/src/util/mod.rs
@@ -79,7 +79,7 @@ pub fn world_len(radius: u16) -> usize {
 // Serialize a HexPointMap as a list instead of a map. This is useful because
 // HexPoints generally shouldn't be used as serialized map keys, since JSON and
 // other formats don't support complex keys.
-pub mod hex_point_map_to_vec_serde {
+pub mod serde_hex_point_map_to_vec {
     use crate::{HasHexPosition, HexPointMap};
     use serde::{
         ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer,

--- a/crates/core/src/world/generate/mod.rs
+++ b/crates/core/src/world/generate/mod.rs
@@ -91,7 +91,7 @@ impl WorldBuilder {
                 }
             }
 
-            debug_assert_eq!(map.len(), capacity, "expected 3r²+3r+1 tiles");
+            assert_eq!(map.len(), capacity, "expected 3r²+3r+1 tiles");
             map
         });
 
@@ -295,14 +295,15 @@ impl TileBuilder {
         *self.runoff_traversed.entry(from_direction).or_default() += runoff;
     }
 
-    /// Clear all runoff from this tile, and return it in a map that determines
-    /// how much runoff to send in each direction. This will always remove
-    /// **all** runoff from this tile, and that runoff will be tracked as
-    /// egress on this tile. The returned map should be used to add that amount
-    /// of runoff to neighboring tiles.
+    /// Clear all runoff from this tile and distribute it to its neighbors,
+    /// according to the pre-calculated runoff pattern. The returned map
+    /// indicates how much runoff to send in each direction. This will
+    /// always remove **all** runoff from this tile, and that runoff will be
+    /// tracked as egress on this tile. The returned map should be used to
+    /// add that amount of runoff to neighboring tiles.
     pub fn distribute_runoff(&mut self) -> HexDirectionMap<Meter3> {
         let distribution =
-            self.runoff_pattern().distribute_exits(self.runoff());
+            self.runoff_pattern().distribute_to_exits(self.runoff());
 
         // If we have anywhere to distribute (i.e. if this tile isn't a
         // terminal), then clear our runoff and count it as egress

--- a/crates/core/src/world/mod.rs
+++ b/crates/core/src/world/mod.rs
@@ -52,7 +52,7 @@ pub struct World {
 
     /// The tiles that make up this world, keyed by their position.
     // Serialize as a vec because hex points can't be keys
-    #[serde(with = "crate::util::hex_point_map_to_vec_serde")]
+    #[serde(with = "crate::util::serde_hex_point_map_to_vec")]
     tiles: HexPointMap<Tile>,
 }
 

--- a/crates/core/tests/test_world_gen.rs
+++ b/crates/core/tests/test_world_gen.rs
@@ -45,3 +45,20 @@ fn test_world_gen_large() {
     let world = World::generate(config).unwrap();
     assert_eq!(world.tiles().len(), 481201);
 }
+
+/// This config had a bug where the entire world was a giant lake. Runoff was
+/// getting multipled by ~1000x during simulation. Runoff simluation contains
+/// some safety checks to ensure simluation doesn't accidentally introduce
+/// new runoff. One of those checks will fail if this bug is present, so as long
+/// as we complete generation without panicking, the bug is gone.
+#[test]
+fn test_world_gen_mega_lake() {
+    let config = WorldConfig {
+        seed: 12507776774975058000,
+        radius: 60,
+        edge_buffer_fraction: 0.025,
+        ..Default::default()
+    };
+    let world = World::generate(config).unwrap();
+    assert_eq!(world.tiles().len(), 10981);
+}


### PR DESCRIPTION
Closes #35 

There was a bug in runoff generation, where runoff that overflowed from one basin into another never got removed from the original, so it magically added more runoff to the system. I reorganized some code, and added a bunch of sanity check asserts to the runoff code to make sure we're not accidentally introducing runoff when we shouldn't be.

Also, the `seed` field in the world config now gets serialized as a string instead of a number, to avoid JSON/TOML issues with very large integer values.