### PR TITLE
[#46] Fix runoff traversal not rendering properly

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -228,8 +228,8 @@ impl Default for RainfallConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            evaporation_default: Meter3(3.0),
-            evaporation_land_scale: 0.2,
+            evaporation_default: Meter3(5.0),
+            evaporation_land_scale: 0.35,
             evaporation_spread_distance: 50,
             evaporation_spread_exponent: 0.6,
             rainfall_fraction_limit: 0.03,
@@ -240,7 +240,7 @@ impl Default for RainfallConfig {
 impl Default for GeoFeatureConfig {
     fn default() -> Self {
         Self {
-            lake_runoff_threshold: Meter3(10.0),
+            lake_runoff_threshold: Meter3(3.0),
             river_runoff_traversed_threshold: Meter3(100.0),
         }
     }

--- a/crates/core/src/world/tile.rs
+++ b/crates/core/src/world/tile.rs
@@ -150,8 +150,8 @@ impl Tile {
     /// **gross** ingress, not the **net**.
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
     pub fn runoff_ingress(&self) -> Meter3 {
+        // Ingress values are positive, so filter out negative values
         std::array::IntoIter::new(self.runoff_traversed.as_array())
-            // Negative values are egress so ignore those
             .filter(|v| *v > Meter3(0.0))
             .sum()
     }
@@ -160,10 +160,11 @@ impl Tile {
     /// **gross** egress, not the **net**.
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
     pub fn runoff_egress(&self) -> Meter3 {
-        std::array::IntoIter::new(self.runoff_traversed.as_array())
-            // Positive values are egress so ignore those
+        // Egress values are negative, so filter out positive values, then
+        // negate the sum
+        -std::array::IntoIter::new(self.runoff_traversed.as_array())
             .filter(|v| *v < Meter3(0.0))
-            .sum()
+            .sum::<Meter3>()
     }
 
     /// Get the tile's biome. Every tile will have exactly on biome assigned.

--- a/demo/src/components/demo/config/WorldConfigEditor.tsx
+++ b/demo/src/components/demo/config/WorldConfigEditor.tsx
@@ -237,8 +237,8 @@ const WorldConfigEditor: React.FC<{ standalone?: boolean }> = ({
         >
           <RangeConfigInput
             min={0.0}
-            max={100.0}
-            step={5.0}
+            max={20.0}
+            step={1.0}
             formatMark={formatMeter3}
           />
         </ConfigInput>


### PR DESCRIPTION
Closes #46 

Runoff traversal wasn't being rendered cause the values were coming out negative. Also, tweaked the runoff and rainfall defaults, because we were getting zero lakes after the bug fix in https://github.com/LucasPickering/terra-rs/pull/45