### PR TITLE
Fix lakes at edge of world

### DIFF
--- a/crates/core/src/world/generate/runoff/basin.rs
+++ b/crates/core/src/world/generate/runoff/basin.rs
@@ -320,14 +320,14 @@ impl Basins {
         unwrap!(self.basins.get_mut(&key), "unknown basin key {}", key)
     }
 
-    /// Has `donor` overflowed into `donee` in the past?
+    /// Has `donor` overflowed into `recipient` in the past?
     pub fn has_previously_overflowed(
         &self,
         donor: TilePoint,
-        donee: TilePoint,
+        recipient: TilePoint,
     ) -> bool {
-        let donee_basin = self.get(donee);
-        donee_basin.prev_donors.contains(&donor.into())
+        let recipient_basin = self.get(recipient);
+        recipient_basin.prev_donors.contains(&donor.into())
     }
 
     /// Join one basin into another, and add some amount of residual overflow


### PR DESCRIPTION
Previously we would get small lakes forming at the edge of the world on smaller worlds (e.g. radius=50). This was because we treated non-existent tiles as being at sea level. Clusters of tiles at the edge of small worlds can be below sea-level, but not large enough to become oceans. That meant they would collect runoff instead of dumping into the void.

## Before

![image](https://user-images.githubusercontent.com/2382935/211106317-ee98386e-0fab-4454-a50d-4cc0bb9ea7ff.png)


## After

![image](https://user-images.githubusercontent.com/2382935/211106258-59e28aed-1dc1-4347-b9aa-91d1119d2493.png)
